### PR TITLE
confined use of std

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 set (CMAKE_C_STANDARD 11)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 
 # Minimum required versions for MSVC
 set (MIN_VS_TOOLSET_VERSION 142)

--- a/Collection.hpp
+++ b/Collection.hpp
@@ -26,7 +26,6 @@
 #include "Exceptions.hpp"
 #include "collection.h"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/ComponentMetaData.hpp
+++ b/ComponentMetaData.hpp
@@ -26,7 +26,6 @@
 #include <string>
 #include "EntityMetaData.hpp"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/ConfigBase.hpp
+++ b/ConfigBase.hpp
@@ -28,7 +28,7 @@
 #include "Exceptions.hpp"
 #include "config.h"
 
-using namespace std;
+using std::vector;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/EngineBase.hpp
+++ b/EngineBase.hpp
@@ -39,7 +39,6 @@
 #include "property.h"
 #include "collection.h"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/EntityMetaData.hpp
+++ b/EntityMetaData.hpp
@@ -27,7 +27,8 @@
 #include <vector>
 #include "data.h"
 
-using namespace std;
+using std::vector;
+using std::string;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/EntityMetaDataBuilder.hpp
+++ b/EntityMetaDataBuilder.hpp
@@ -28,7 +28,6 @@
 #include "collection.h"
 #include "string.h"
 
-using namespace std;
 
 using namespace FiftyoneDegrees;
 

--- a/EvidenceBase.hpp
+++ b/EvidenceBase.hpp
@@ -28,7 +28,10 @@
 #include "Exceptions.hpp"
 #include "evidence.h"
 
-using namespace std;
+using std::map;
+using std::make_shared;
+using std::invalid_argument;
+using std::stringstream;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/Exceptions.cpp
+++ b/Exceptions.cpp
@@ -23,7 +23,6 @@
 #include "Exceptions.hpp"
 #include "fiftyone.h"
 
-using namespace std;
 using namespace FiftyoneDegrees::Common;
 
 StatusCodeException::StatusCodeException() {}

--- a/Exceptions.hpp
+++ b/Exceptions.hpp
@@ -26,11 +26,15 @@
 #include <string>
 #include <exception>
 #include <stdexcept>
+#include <memory>
 #include "exceptions.h"
 #include "status.h"
 #include "memory.h"
 
-using namespace std;
+using std::runtime_error;
+using std::string;
+using std::exception;
+using std::shared_ptr;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/MetaData.hpp
+++ b/MetaData.hpp
@@ -31,6 +31,8 @@
 #include "resource.h"
 #include <memory>
 
+using std::shared_ptr;
+
 namespace FiftyoneDegrees {
 	namespace Common {
 		/**

--- a/ProfileMetaData.hpp
+++ b/ProfileMetaData.hpp
@@ -26,7 +26,7 @@
 #include <string>
 #include "EntityMetaData.hpp"
 
-using namespace std;
+using std::vector;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/PropertyMetaData.hpp
+++ b/PropertyMetaData.hpp
@@ -27,7 +27,6 @@
 #include <vector>
 #include "EntityMetaData.hpp"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/RequiredPropertiesConfig.hpp
+++ b/RequiredPropertiesConfig.hpp
@@ -27,7 +27,8 @@
 #include <vector>
 #include "properties.h"
 
-using namespace std;
+using std::string;
+using std::vector;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/ResultsBase.hpp
+++ b/ResultsBase.hpp
@@ -33,7 +33,8 @@
 #include "results.h"
 #include "resource.h"
 
-using namespace std;
+using std::shared_ptr;
+using std::stringstream;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/Value.hpp
+++ b/Value.hpp
@@ -26,7 +26,6 @@
 #include "Exceptions.hpp"
 #include "results.h"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/ValueMetaData.hpp
+++ b/ValueMetaData.hpp
@@ -28,7 +28,6 @@
 #include "EntityMetaData.hpp"
 #include "value.h"
 
-using namespace std;
 
 namespace FiftyoneDegrees {
 	namespace Common {

--- a/tests/Base.hpp
+++ b/tests/Base.hpp
@@ -44,7 +44,8 @@ typedef struct memoryStates_t {
 } memoryStates;
 #endif
 
-using namespace std;
+using std::stringstream;
+using std::cout;
 
 /**
  * Adds a test to check the value returned by a get method is equal to the

--- a/tests/CoordinateTests.cpp
+++ b/tests/CoordinateTests.cpp
@@ -26,8 +26,6 @@
 #include "../string.h"
 #include "../coordinate.h"
 
-using namespace std;
-
 /*
  * fiftyoneDegreesCoordinate extract coordinate from String item test
  */

--- a/tests/EngineTests.cpp
+++ b/tests/EngineTests.cpp
@@ -27,6 +27,9 @@
 #define THREAD_COUNT 4
 #endif
 
+using std::hash;
+using std::thread;
+
 EngineTests::EngineTests(
 	RequiredPropertiesConfig *requiredProperties,
 	const char *directory,

--- a/tests/ValueTests.cpp
+++ b/tests/ValueTests.cpp
@@ -24,6 +24,7 @@
 #include "Base.hpp"
 #include "../Value.hpp"
 
+using std::vector;
 using namespace FiftyoneDegrees::Common;
 
 /**


### PR DESCRIPTION
to resolve the name collision of std::byte and typedef byte when building with C++17